### PR TITLE
Modified the macro so the WorkFeature folder can be placed somewhere else

### DIFF
--- a/start_WF.FCMacro
+++ b/start_WF.FCMacro
@@ -6,13 +6,27 @@ try:
     # try import
     import WorkFeature.WF_2015 as WF
 except:
-    # get the path of the current python script    
-    m_current_path = os.path.realpath(__file__)
-    m_current_path = os.path.dirname(m_current_path)
+    # first check if the path to WorkFeature was set in the preferences
+    param = FreeCAD.ParamGet('User parameter:Plugins/workfeature')
+    m_current_path = param.GetString('destination','')
+    if not m_current_path:
+        # get the path of the current python script    
+        m_current_path = os.path.realpath(__file__)
+        m_current_path = os.path.dirname(m_current_path)
     # check if this path belongs to the PYTHONPATH variable and if not add it
     if not sys.path.__contains__(str(m_current_path)):
         sys.path.append(str(m_current_path))
     # retry import now
-    import WorkFeature.WF_2015 as WF
+    try:
+        import WorkFeature.WF_2015 as WF
+    except:
+        # we still cannot find WorkFeature. Ask the user
+        from PySide import QtGui
+        folderDialog = QtGui.QFileDialog.getExistingDirectory(None,QtGui.QApplication.translate("WorkFeature", "Location of your WorkFeature folder", None, QtGui.QApplication.UnicodeUTF8))
+        param.SetString('destination',folderDialog)
+        m_current_path = param.GetString('destination')
+        sys.path.append(str(m_current_path))
+        # retry import
+        import WorkFeature.WF_2015 as WF
   
 WF.myDialog = WF.WorkFeatureTab()


### PR DESCRIPTION
Hi Rentlau,

I did a small change to the workfeature start macro, in order to allow the macro to be placed somewhere else than its WorkFeature folder. This is useful for the new installer we're preparing at https://github.com/FreeCAD/FreeCAD-addons (which will place everything in a separate folder, then copy the FCMacro files to the macros folder).

How it worked before:
- the macro tries to import WF
- if not found, the macro tries to add the current folder to sys.path

How it works now:
- the macro tries to import WF
- if not found, the macro sees if the path to WF has been stored in the FreeCAD preferences
- if not, the macro tries to add the current folder to sys.path (same as before)
- if still not found, a dialog pops up to ask the user for the path to WF

Hope you can add it!
Cheers
Yorik
